### PR TITLE
improvement(Tree): don't preserve nested expanded keys when a node co…

### DIFF
--- a/packages/jui/src/Tree/Tree.cy-test.tsx
+++ b/packages/jui/src/Tree/Tree.cy-test.tsx
@@ -1,0 +1,29 @@
+import { mount } from "@cypress/react";
+import { composeStories } from "@storybook/testing-react";
+import * as React from "react";
+import * as stories from "./Tree.stories";
+
+const { Static } = composeStories(stories);
+
+describe("Tree", () => {
+  it("opens nested expandable single-child items", () => {
+    mount(<Static />);
+
+    cy.contains("Foo").click().type("{enter}");
+    matchImageSnapshot("Tree-nested-single-child-expansion");
+  });
+
+  it("collapses descendant items of a node that is collapsed", () => {
+    mount(<Static />);
+
+    cy.contains("List") // "List" item is expanded by default and has expanded children
+      .click() // select it
+      .type("{enter}") // collapse it
+      .type("{enter}"); // collapse expand it. Initially expanded children should now be collapsed
+    matchImageSnapshot("Tree-children-collapsed-when-parent-collapsed");
+  });
+});
+
+function matchImageSnapshot(snapshotsName: string) {
+  cy.percySnapshot(snapshotsName);
+}

--- a/packages/jui/src/Tree/Tree.stories.tsx
+++ b/packages/jui/src/Tree/Tree.stories.tsx
@@ -46,6 +46,17 @@ export const Static = () => {
           <Item title="Theme" key="Theme">
             <Item>createTheme.ts</Item>
           </Item>
+          <Item title="Foo">
+            <Item title="Bar">
+              <Item title="FooBar">
+                <Item title="Baz">
+                  <Item>Baz.ts</Item>
+                </Item>
+                <Item>Foo.ts</Item>
+                <Item>Bar.ts</Item>
+              </Item>
+            </Item>
+          </Item>
         </Tree>
       </Pane>
       <div style={{ marginLeft: 20 }}>


### PR DESCRIPTION
…llapses

Unrelated other fix: calling onNodeKeyDown in SpeedSearchTreeWithCheckboxes was missed.